### PR TITLE
Add compatibility selector for 2021 YouTube Layout

### DIFF
--- a/src/elements.ts
+++ b/src/elements.ts
@@ -1,6 +1,6 @@
 export function getYouTubeTitleNodeSelector(): string {
     // New YouTube Title, YouTube, Mobile YouTube, Invidious, YouTube videoPrimaryInfoRenderer (2021) layout
-    return "#title h1, .ytd-video-primary-info-renderer.title, .slim-video-information-title, #player-container + .h-box > h1, h1.title";
+    return "#title h1, .ytd-video-primary-info-renderer.title, .slim-video-information-title, #player-container + .h-box > h1, .ytd-video-primary-info-renderer > h1.title";
 }
 
 export function getYouTubeTitleNode(): HTMLElement {

--- a/src/elements.ts
+++ b/src/elements.ts
@@ -1,6 +1,6 @@
 export function getYouTubeTitleNodeSelector(): string {
-    // New YouTube Title, YouTube, Mobile YouTube, Invidious
-    return "#title h1, .ytd-video-primary-info-renderer.title, .slim-video-information-title, #player-container + .h-box > h1";
+    // New YouTube Title, YouTube, Mobile YouTube, Invidious, YouTube videoPrimaryInfoRenderer (2021) layout
+    return "#title h1, .ytd-video-primary-info-renderer.title, .slim-video-information-title, #player-container + .h-box > h1, h1.title";
 }
 
 export function getYouTubeTitleNode(): HTMLElement {


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/maze-utils/blob/master/LICENSE-APPSTORE.txt)

***
flags:
```js
window.yt.config_.EXPERIMENT_FLAGS.kevlar_watch_metadata_refresh = false;
window.yt.config_.EXPERIMENT_FLAGS.kevlar_watch_metadata_refresh_no_old_secondary_data = false;
```

Taken from https://greasyfork.org/en/scripts/478159-youtube-2021-layout
https://discord.com/channels/603643120093233162/603643180663177220/1222999468442386454
![image](https://github.com/ajayyy/maze-utils/assets/15132783/e958ee24-8b2a-4b8b-93a8-3459833b48b8)
