### PR TITLE
Add checks in findAllVideoIds() to eliminate infinite recursion when using V3

### DIFF
--- a/src/injected/document.ts
+++ b/src/injected/document.ts
@@ -185,10 +185,14 @@ function findAllVideoIds(data: Record<string, unknown>): Set<string> {
     const videoIds: Set<string> = new Set();
     
     for (const key in data) {
+        let entry = data[key];
         if (key === "videoId") {
-            videoIds.add(data[key] as string);
-        } else if (typeof(data[key]) === "object" && !ytInfoKeysToIgnore.includes(key)) {
-            findAllVideoIds(data[key] as Record<string, unknown>).forEach(id => videoIds.add(id));
+            videoIds.add(entry as string);
+        } else if (entry != null
+                   && typeof(entry) === "object"
+                   && !ytInfoKeysToIgnore.includes(key)
+                   && !(entry instanceof Node)) {
+            findAllVideoIds(entry as Record<string, unknown>).forEach(id => videoIds.add(id));
         }
     }
 


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/maze-utils/blob/master/LICENSE-APPSTORE.txt)

***
This commit introduces a check against circular references in Node entries (e.g. HTMLElement). 

Context: V3 attaches DOM references to `ytInitialData`, as a result, Sponsorblock's recursive tree traversal and `videoId` lookup leads to an infinite loop. The added checks ensure this doesn't happen.