### PR TITLE
Support Invidious raw id query param

### DIFF
--- a/src/video.ts
+++ b/src/video.ts
@@ -368,6 +368,16 @@ export function parseYouTubeVideoIDFromURL(url: string): ParsedVideoURL {
                 callLater: false
             };
         }
+    } else if (onInvidious && urlObject.searchParams.has("id")) {
+        const id = urlObject.searchParams.get("id");
+        return {
+            videoID: id?.length >= 11 ? id.slice(0, 11) as VideoID : null,
+            onInvidious,
+            onMobileYouTube,
+            onYTTV,
+            onYouTubeMusic,
+            callLater: false
+        };
     }
 
     return {


### PR DESCRIPTION
## Summary
- Parse the `id` query param on Invidious URLs so raw endpoints (for example, /latest_version?id=...&raw=1) resolve a video ID

## Testing
- Not run (not requested)

## Context
- Related SponsorBlock issue: [ajayyy/SponsorBlock#696](https://github.com/ajayyy/SponsorBlock/issues/696)
