### PR TITLE
Update detection of embedded player

### DIFF
--- a/src/video.ts
+++ b/src/video.ts
@@ -51,8 +51,8 @@ interface VideoModuleParams {
     allowClipPage?: boolean;
 }
 
-const embedTitleSelector = "a.ytp-title-link[data-sessionlink='feature=player-title']:not(.cbCustomTitle)";
-const channelTrailerTitleSelector = "ytd-channel-video-player-renderer a.ytp-title-link[data-sessionlink='feature=player-title']:not(.cbCustomTitle)";
+const embedTitleSelector = "a.ytmVideoInfoVideoTitle:not(.cbCustomTitle)";
+const channelTrailerTitleSelector = "ytd-channel-video-player-renderer a.ytp-title-link:not(.cbCustomTitle)";
 
 let video: HTMLVideoElement | null = null;
 let videoWidth: string | null = null;


### PR DESCRIPTION
Youtube has rolled out use of the mobile player for all embeds.  I'm not sure if that's a mistake on their part, but it started over a month ago and looks like a progressive deployment to me.

This updates the selector for finding the embedded player title, which has a small change in class name.

Tested on Chromium

- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/maze-utils/blob/master/LICENSE-APPSTORE.txt)

***
