### PR TITLE
fix server requests hanging if sendMessage promise resolves to undefined

### DIFF
--- a/src/background-request-proxy.ts
+++ b/src/background-request-proxy.ts
@@ -141,7 +141,9 @@ export function sendRequestToCustomServer(type: string, url: string, data = {}, 
             data,
             headers
         }, (response) => {
-            if ("error" in response) {
+            if (response == null) {
+                reject(new Error(`Got ${response} response from background page`));
+            } else if ("error" in response) {
                 reject(response.error);
             } else {
                 resolve(response);
@@ -162,7 +164,9 @@ export function sendBinaryRequestToCustomServer(type: string, url: string, data 
             binary: true,
             returnHeaders: true
         }, (response) => {
-            if ("error" in response) {
+            if (response == null) {
+                reject(new Error(`Got ${response} response from background page`));
+            } else if ("error" in response) {
                 reject(response.error);
             } else {
                 resolve(response);


### PR DESCRIPTION
- [x] I agree to license my contribution under GPL-3.0 and agree to allow distribution on app stores as outlined in [LICENSE-APPSTORE](https://github.com/ajayyy/maze-utils/blob/master/LICENSE-APPSTORE.txt)

***
this is a fix for [an issue reported on discord](https://discord.com/channels/603643120093233162/897699762738966558/1497649377878081597)
this may fix request promises hanging indefinitely (which may manifest as titles/thumbnails disappearing when using dearrow) but doesn't actually fix the underlying issue of `sendMessage` returning `undefined` unexpectedly, as there isn't enough info about the circumstances of this issue